### PR TITLE
use cupy to compute pixel_index_map on the device

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -188,7 +188,7 @@ def run_simulation(input_filename,
         d_neighboring_pixels = cupy.array(neighboring_pixels)
         d_unique_pix = cupy.array(unique_pix)
         d_pixel_index_map = cupy.full((selected_tracks.shape[0], neighboring_pixels.shape[1]), -1)
-        compare = neighboring_pixels[..., np.newaxis, :] == unique_pix
+        compare = d_neighboring_pixels[..., np.newaxis, :] == d_unique_pix
         indices = cupy.where(cupy.logical_and(compare[..., 0], compare[..., 1]))
         d_pixel_index_map[indices[0], indices[1]] = indices[2]
         RangePop()

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -188,7 +188,8 @@ def run_simulation(input_filename,
         d_neighboring_pixels = cupy.array(neighboring_pixels)
         d_unique_pix = cupy.array(unique_pix)
         d_pixel_index_map = cupy.full((selected_tracks.shape[0], neighboring_pixels.shape[1]), -1)
-        indices = cupy.where((d_neighboring_pixels[..., 0, np.newaxis] == d_unique_pix[:, 0]) & (d_neighboring_pixels[..., 1, np.newaxis] == d_unique_pix[:, 1]))
+        compare = neighboring_pixels[..., np.newaxis, :] == unique_pix
+        indices = cp.where(cp.logical_and(compare[..., 0], compare[..., 1]))
         d_pixel_index_map[indices[0], indices[1]] = indices[2]
         RangePop()
 

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -189,7 +189,7 @@ def run_simulation(input_filename,
         d_unique_pix = cupy.array(unique_pix)
         d_pixel_index_map = cupy.full((selected_tracks.shape[0], neighboring_pixels.shape[1]), -1)
         compare = neighboring_pixels[..., np.newaxis, :] == unique_pix
-        indices = cp.where(cp.logical_and(compare[..., 0], compare[..., 1]))
+        indices = cupy.where(cupy.logical_and(compare[..., 0], compare[..., 1]))
         d_pixel_index_map[indices[0], indices[1]] = indices[2]
         RangePop()
 


### PR DESCRIPTION
This PR moves the computation of `pixel_index_map` to the device using cupy and uses array broadcasting to avoid nested for loops.

From the nsight profile, it looks like the runtime for this step goes from ~200ms to ~20ms.