### PR TITLE
add timing statements

### DIFF
--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -400,17 +400,17 @@ def backtrack_adcs(tracks, adc_list, adc_times_list, track_pixel_map, event_id_m
                             if counter < backtracked_id.shape[2]:
                                 backtracked_id[ip,iadc,counter] = tracks["trackID"][track_index]
 
-@nb.njit
+@cuda.jit
 def get_track_pixel_map(track_pixel_map, unique_pix, pixels):
-
-    for itrk in range(pixels.shape[0]):
-        pixIDs = pixels[itrk]
-
-        for pixID in pixIDs:
-            if pixID[0] != -1:
-                idx = np.where((unique_pix[:,0] == pixID[0]) & (unique_pix[:,1] == pixID[1]))[0][0]
+    # index of unique_pix array
+    index = cuda.grid(1)
+    upix = unique_pix[index]
+    for itr in range(pixels.shape[0]):
+        for ipix in range(pixels.shape[1]):
+            pID = pixels[itr][ipix]
+            if upix[0] == pID[0] and upix[1] == pID[1]:
                 imap = 0
-                while imap < track_pixel_map.shape[1] and track_pixel_map[idx][imap] != -1:
-                    imap+=1
+                while imap < track_pixel_map.shape[1] and track_pixel_map[index][imap] != -1:
+                    imap += 1
                 if imap < track_pixel_map.shape[1]:
-                    track_pixel_map[idx][imap] = itrk
+                    track_pixel_map[index][imap] = itr


### PR DESCRIPTION
This PR adds a few timing statements to measure:
 * total time of run_simulation
 * total time of batched track simulation loop
 * time of the batched track simulation loop exlcuding the first iteration (to ignore kernel compilation time)

Example output:

```
$ python cli/simulate_pixels.py --input_filename examples/edepsim_1M.h5 --output_filename=test.h5 --n_tracks=2000 --pixel_layout=larndsim/pixel_layouts/layout-singlecube.yaml --detector_properties=larndsim/detector_properties/singlecube.yaml

  _                      _            _
 | |                    | |          (_)
 | | __ _ _ __ _ __   __| |______ ___ _ _ __ ___
 | |/ _` | '__| '_ \ / _` |______/ __| | '_ ` _ \
 | | (_| | |  | | | | (_| |      \__ \ | | | | | |
 |_|\__,_|_|  |_| |_|\__,_|      |___/_|_| |_| |_|


**************************
LOADING SETTINGS AND INPUT
**************************
Pixel layout file: larndsim/pixel_layouts/layout-singlecube.yaml
Detector propeties file: larndsim/detector_properties/singlecube.yaml
edep-sim input file: examples/edepsim_1M.h5
*******************
STARTING SIMULATION
*******************
Quenching electrons... 0.66 s
Drifting electrons... 0.52 s
Simulating pixels...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:08<00:00,  1.16it/s]
- total time: 8.62 s
- excluding first iteration: 1.60 s
Writing to HDF5...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20096/20096 [00:00<00:00, 22671.57it/s]
Output saved in: test.h5
run_simulation elapsed time: 18.30 s
```