### PR TITLE
speed up track_pixel_map

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -242,7 +242,7 @@ def run_simulation(input_filename,
         # Here we backtrack the ADC counts to the Geant4 tracks
         TPB = 128
         BPG = ceil(adc_list.shape[0] / TPB)
-        backtracked_id = np.full((adc_list.shape[0], adc_list.shape[1], 5), -1)
+        backtracked_id = cp.full((adc_list.shape[0], adc_list.shape[1], backtracked_id_tot.shape[2]), -1)
         detsim.backtrack_adcs[BPG,TPB](selected_tracks,
                                        adc_list,
                                        adc_ticks_list,
@@ -253,7 +253,7 @@ def run_simulation(input_filename,
         adc_tot_list = cp.concatenate((adc_tot_list, adc_list), axis=0)
         adc_tot_ticks_list = cp.concatenate((adc_tot_ticks_list, adc_ticks_list), axis=0)
         unique_pix_tot = cp.concatenate((unique_pix_tot, unique_pix), axis=0)
-        backtracked_id_tot = cp.concatenate((backtracked_id_tot, cp.asarray(backtracked_id)), axis=0)
+        backtracked_id_tot = cp.concatenate((backtracked_id_tot, backtracked_id), axis=0)
         tot_events += len(unique_eventIDs)
         RangePop()
         end_tracks_batch = time()

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -400,3 +400,17 @@ def backtrack_adcs(tracks, adc_list, adc_times_list, track_pixel_map, event_id_m
                             if counter < backtracked_id.shape[2]:
                                 backtracked_id[ip,iadc,counter] = tracks["trackID"][track_index]
 
+@cuda.jit
+def get_track_pixel_map(track_pixel_map, unique_pix, pixels):
+    # index of unique_pix array
+    index = cuda.grid(1)
+    upix = unique_pix[index]
+    for itr in range(pixels.shape[0]):
+        for ipix in range(pixels.shape[1]):
+            pID = pixels[itr][ipix]
+            if upix[0] == pID[0] and upix[1] == pID[1]:
+                imap = 0
+                while imap < track_pixel_map.shape[1] and track_pixel_map[index][imap] != -1:
+                    imap += 1
+                if imap < track_pixel_map.shape[1]:
+                    track_pixel_map[index][imap] = itr

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -400,17 +400,3 @@ def backtrack_adcs(tracks, adc_list, adc_times_list, track_pixel_map, event_id_m
                             if counter < backtracked_id.shape[2]:
                                 backtracked_id[ip,iadc,counter] = tracks["trackID"][track_index]
 
-@nb.njit
-def get_track_pixel_map(track_pixel_map, unique_pix, pixels):
-
-    for itrk in range(pixels.shape[0]):
-        pixIDs = pixels[itrk]
-
-        for pixID in pixIDs:
-            if pixID[0] != -1:
-                idx = np.where((unique_pix[:,0] == pixID[0]) & (unique_pix[:,1] == pixID[1]))[0][0]
-                imap = 0
-                while imap < track_pixel_map.shape[1] and track_pixel_map[idx][imap] != -1:
-                    imap+=1
-                if imap < track_pixel_map.shape[1]:
-                    track_pixel_map[idx][imap] = itrk


### PR DESCRIPTION
This PR speeds up the computation of `track_pixel_map` by reusing the index arrays that were used to create `pixel_index_map` earlier.

This improves the runtime of the batched track simulation loop (excluding the first iteration) by ~ 1.5 s / 1.2 s = 1.25x for ntracks=2000.

```
$ python cli/simulate_pixels.py --input_filename examples/edepsim_1M.h5 --output_filename=test.h5 --n_tracks=2000 --pixel_layout=larndsim/pixel_layouts/layout-singlecube.yaml --detector_properties=larndsim/detector_properties/singlecube.yaml

  _                      _            _
 | |                    | |          (_)
 | | __ _ _ __ _ __   __| |______ ___ _ _ __ ___
 | |/ _` | '__| '_ \ / _` |______/ __| | '_ ` _ \
 | | (_| | |  | | | | (_| |      \__ \ | | | | | |
 |_|\__,_|_|  |_| |_|\__,_|      |___/_|_| |_| |_|


**************************
LOADING SETTINGS AND INPUT
**************************
Pixel layout file: larndsim/pixel_layouts/layout-singlecube.yaml
Detector propeties file: larndsim/detector_properties/singlecube.yaml
edep-sim input file: examples/edepsim_1M.h5
*******************
STARTING SIMULATION
*******************
Quenching electrons... 0.90 s
Drifting electrons... 0.51 s
Simulating pixels...: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:07<00:00,  1.26it/s]
- total time: 7.95 s
- excluding first iteration: 1.19 s
Writing to HDF5...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20096/20096 [00:00<00:00, 22749.55it/s]
Output saved in: test.h5
run_simulation elapsed time: 18.34 s
```

Note that this PR is based on #4 